### PR TITLE
chore: migrate to `policy/v1`

### DIFF
--- a/deploy/manager/dev/10_controller_pdb.yaml
+++ b/deploy/manager/dev/10_controller_pdb.yaml
@@ -1,4 +1,4 @@
-apiVersion: policy/v1beta1
+apiVersion: policy/v1
 kind: PodDisruptionBudget
 metadata:
   name: scylla-manager-controller

--- a/deploy/manager/prod/10_controller_pdb.yaml
+++ b/deploy/manager/prod/10_controller_pdb.yaml
@@ -1,4 +1,4 @@
-apiVersion: policy/v1beta1
+apiVersion: policy/v1
 kind: PodDisruptionBudget
 metadata:
   name: scylla-manager-controller

--- a/deploy/operator/10_operator.pdb.yaml
+++ b/deploy/operator/10_operator.pdb.yaml
@@ -1,4 +1,4 @@
-apiVersion: policy/v1beta1
+apiVersion: policy/v1
 kind: PodDisruptionBudget
 metadata:
   name: scylla-operator

--- a/deploy/operator/10_webhookserver.pdb.yaml
+++ b/deploy/operator/10_webhookserver.pdb.yaml
@@ -1,4 +1,4 @@
-apiVersion: policy/v1beta1
+apiVersion: policy/v1
 kind: PodDisruptionBudget
 metadata:
   name: webhook-server

--- a/examples/common/manager.yaml
+++ b/examples/common/manager.yaml
@@ -96,7 +96,7 @@ metadata:
   name: scylla-manager
 
 ---
-apiVersion: policy/v1beta1
+apiVersion: policy/v1
 kind: PodDisruptionBudget
 metadata:
   name: scylla-manager-controller

--- a/examples/common/operator.yaml
+++ b/examples/common/operator.yaml
@@ -2436,7 +2436,7 @@ spec:
   selfSigned: {}
 
 ---
-apiVersion: policy/v1beta1
+apiVersion: policy/v1
 kind: PodDisruptionBudget
 metadata:
   name: scylla-operator
@@ -2489,7 +2489,7 @@ webhooks:
     - scyllaclusters
 
 ---
-apiVersion: policy/v1beta1
+apiVersion: policy/v1
 kind: PodDisruptionBudget
 metadata:
   name: webhook-server

--- a/helm/scylla-manager/templates/controller_pdb.yaml
+++ b/helm/scylla-manager/templates/controller_pdb.yaml
@@ -1,4 +1,4 @@
-apiVersion: policy/v1beta1
+apiVersion: policy/v1
 kind: PodDisruptionBudget
 metadata:
   name: scylla-manager-controller

--- a/helm/scylla-operator/templates/operator.pdb.yaml
+++ b/helm/scylla-operator/templates/operator.pdb.yaml
@@ -1,5 +1,5 @@
 {{- if gt .Values.replicas 1.0 }}
-apiVersion: policy/v1beta1
+apiVersion: policy/v1
 kind: PodDisruptionBudget
 metadata:
   name: scylla-operator

--- a/helm/scylla-operator/templates/webhookserver.pdb.yaml
+++ b/helm/scylla-operator/templates/webhookserver.pdb.yaml
@@ -1,5 +1,5 @@
 {{- if gt .Values.webhookServerReplicas 1.0 }}
-apiVersion: policy/v1beta1
+apiVersion: policy/v1
 kind: PodDisruptionBudget
 metadata:
   name: webhook-server

--- a/pkg/cmd/operator/operator.go
+++ b/pkg/cmd/operator/operator.go
@@ -181,7 +181,7 @@ func (o *OperatorOptions) run(ctx context.Context, streams genericclioptions.IOS
 		kubeInformers.Core().V1().Services(),
 		kubeInformers.Core().V1().Secrets(),
 		kubeInformers.Apps().V1().StatefulSets(),
-		kubeInformers.Policy().V1beta1().PodDisruptionBudgets(),
+		kubeInformers.Policy().V1().PodDisruptionBudgets(),
 		scyllaInformers.Scylla().V1().ScyllaClusters(),
 		o.OperatorImage,
 	)

--- a/pkg/controller/scyllacluster/controller.go
+++ b/pkg/controller/scyllacluster/controller.go
@@ -14,7 +14,7 @@ import (
 	"github.com/scylladb/scylla-operator/pkg/scheme"
 	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
-	policyv1beta1 "k8s.io/api/policy/v1beta1"
+	policyv1 "k8s.io/api/policy/v1"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
@@ -23,12 +23,12 @@ import (
 	"k8s.io/apimachinery/pkg/util/wait"
 	appsv1informers "k8s.io/client-go/informers/apps/v1"
 	corev1informers "k8s.io/client-go/informers/core/v1"
-	policyv1beta1informers "k8s.io/client-go/informers/policy/v1beta1"
+	policyv1informers "k8s.io/client-go/informers/policy/v1"
 	"k8s.io/client-go/kubernetes"
 	corev1client "k8s.io/client-go/kubernetes/typed/core/v1"
 	appsv1listers "k8s.io/client-go/listers/apps/v1"
 	corev1listers "k8s.io/client-go/listers/core/v1"
-	policyv1beta1listers "k8s.io/client-go/listers/policy/v1beta1"
+	policyv1listers "k8s.io/client-go/listers/policy/v1"
 	"k8s.io/client-go/tools/cache"
 	"k8s.io/client-go/tools/record"
 	"k8s.io/client-go/util/workqueue"
@@ -61,7 +61,7 @@ type Controller struct {
 	serviceLister     corev1listers.ServiceLister
 	secretLister      corev1listers.SecretLister
 	statefulSetLister appsv1listers.StatefulSetLister
-	pdbLister         policyv1beta1listers.PodDisruptionBudgetLister
+	pdbLister         policyv1listers.PodDisruptionBudgetLister
 	scyllaLister      scyllav1listers.ScyllaClusterLister
 
 	cachesToSync []cache.InformerSynced
@@ -78,7 +78,7 @@ func NewController(
 	serviceInformer corev1informers.ServiceInformer,
 	secretInformer corev1informers.SecretInformer,
 	statefulSetInformer appsv1informers.StatefulSetInformer,
-	pdbInformer policyv1beta1informers.PodDisruptionBudgetInformer,
+	pdbInformer policyv1informers.PodDisruptionBudgetInformer,
 	scyllaClusterInformer scyllav1informers.ScyllaClusterInformer,
 	operatorImage string,
 ) (*Controller, error) {
@@ -515,14 +515,14 @@ func (scc *Controller) deleteStatefulSet(obj interface{}) {
 }
 
 func (scc *Controller) addPodDisruptionBudget(obj interface{}) {
-	pdb := obj.(*policyv1beta1.PodDisruptionBudget)
+	pdb := obj.(*policyv1.PodDisruptionBudget)
 	klog.V(4).InfoS("Observed addition of PodDisruptionBudget", "PodDisruptionBudget", klog.KObj(pdb))
 	scc.enqueueOwner(pdb)
 }
 
 func (scc *Controller) updatePodDisruptionBudget(old, cur interface{}) {
-	oldPDB := old.(*policyv1beta1.PodDisruptionBudget)
-	currentPDB := cur.(*policyv1beta1.PodDisruptionBudget)
+	oldPDB := old.(*policyv1.PodDisruptionBudget)
+	currentPDB := cur.(*policyv1.PodDisruptionBudget)
 
 	if currentPDB.UID != oldPDB.UID {
 		key, err := keyFunc(oldPDB)
@@ -541,14 +541,14 @@ func (scc *Controller) updatePodDisruptionBudget(old, cur interface{}) {
 }
 
 func (scc *Controller) deletePodDisruptionBudget(obj interface{}) {
-	pdb, ok := obj.(*policyv1beta1.PodDisruptionBudget)
+	pdb, ok := obj.(*policyv1.PodDisruptionBudget)
 	if !ok {
 		tombstone, ok := obj.(cache.DeletedFinalStateUnknown)
 		if !ok {
 			utilruntime.HandleError(fmt.Errorf("couldn't get object from tombstone %#v", obj))
 			return
 		}
-		pdb, ok = tombstone.Obj.(*policyv1beta1.PodDisruptionBudget)
+		pdb, ok = tombstone.Obj.(*policyv1.PodDisruptionBudget)
 		if !ok {
 			utilruntime.HandleError(fmt.Errorf("tombstone contained object that is not a PodDisruptionBudget %#v", obj))
 			return

--- a/pkg/controller/scyllacluster/resource.go
+++ b/pkg/controller/scyllacluster/resource.go
@@ -10,7 +10,7 @@ import (
 	"github.com/scylladb/scylla-operator/pkg/naming"
 	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
-	"k8s.io/api/policy/v1beta1"
+	policyv1 "k8s.io/api/policy/v1"
 	"k8s.io/apimachinery/pkg/api/resource"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/util/intstr"
@@ -600,9 +600,9 @@ func agentContainer(r scyllav1.RackSpec, c *scyllav1.ScyllaCluster) corev1.Conta
 	return cnt
 }
 
-func MakePodDisruptionBudget(c *scyllav1.ScyllaCluster) *v1beta1.PodDisruptionBudget {
+func MakePodDisruptionBudget(c *scyllav1.ScyllaCluster) *policyv1.PodDisruptionBudget {
 	maxUnavailable := intstr.FromInt(1)
-	return &v1beta1.PodDisruptionBudget{
+	return &policyv1.PodDisruptionBudget{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      naming.PodDisruptionBudgetName(c),
 			Namespace: c.Namespace,
@@ -611,7 +611,7 @@ func MakePodDisruptionBudget(c *scyllav1.ScyllaCluster) *v1beta1.PodDisruptionBu
 			},
 			Labels: naming.ClusterLabels(c),
 		},
-		Spec: v1beta1.PodDisruptionBudgetSpec{
+		Spec: policyv1.PodDisruptionBudgetSpec{
 			MaxUnavailable: &maxUnavailable,
 			Selector:       metav1.SetAsLabelSelector(naming.ClusterLabels(c)),
 		},

--- a/pkg/controller/scyllacluster/sync.go
+++ b/pkg/controller/scyllacluster/sync.go
@@ -10,7 +10,7 @@ import (
 	"github.com/scylladb/scylla-operator/pkg/naming"
 	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
-	policyv1beta1 "k8s.io/api/policy/v1beta1"
+	policyv1 "k8s.io/api/policy/v1"
 	"k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/labels"
@@ -151,7 +151,7 @@ func (scc *Controller) getSecrets(ctx context.Context, sc *scyllav1.ScyllaCluste
 	return cm.ClaimSecrets(secrets)
 }
 
-func (scc *Controller) getPDBs(ctx context.Context, sc *scyllav1.ScyllaCluster) (map[string]*policyv1beta1.PodDisruptionBudget, error) {
+func (scc *Controller) getPDBs(ctx context.Context, sc *scyllav1.ScyllaCluster) (map[string]*policyv1.PodDisruptionBudget, error) {
 	// List all Pdbs to find even those that no longer match our selector.
 	// They will be orphaned in ClaimPdbs().
 	pdbs, err := scc.pdbLister.PodDisruptionBudgets(sc.Namespace).List(labels.Everything())

--- a/pkg/controller/scyllacluster/sync_pdb.go
+++ b/pkg/controller/scyllacluster/sync_pdb.go
@@ -6,7 +6,7 @@ import (
 
 	scyllav1 "github.com/scylladb/scylla-operator/pkg/api/scylla/v1"
 	"github.com/scylladb/scylla-operator/pkg/resourceapply"
-	policyv1beta1 "k8s.io/api/policy/v1beta1"
+	policyv1 "k8s.io/api/policy/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	utilerrors "k8s.io/apimachinery/pkg/util/errors"
 )
@@ -15,7 +15,7 @@ func (scc *Controller) syncPodDisruptionBudgets(
 	ctx context.Context,
 	sc *scyllav1.ScyllaCluster,
 	status *scyllav1.ScyllaClusterStatus,
-	pdbs map[string]*policyv1beta1.PodDisruptionBudget,
+	pdbs map[string]*policyv1.PodDisruptionBudget,
 ) (*scyllav1.ScyllaClusterStatus, error) {
 	var err error
 
@@ -34,7 +34,7 @@ func (scc *Controller) syncPodDisruptionBudgets(
 		}
 
 		propagationPolicy := metav1.DeletePropagationBackground
-		err = scc.kubeClient.PolicyV1beta1().PodDisruptionBudgets(pdb.Namespace).Delete(ctx, pdb.Name, metav1.DeleteOptions{
+		err = scc.kubeClient.PolicyV1().PodDisruptionBudgets(pdb.Namespace).Delete(ctx, pdb.Name, metav1.DeleteOptions{
 			Preconditions: &metav1.Preconditions{
 				UID: &pdb.UID,
 			},
@@ -48,7 +48,7 @@ func (scc *Controller) syncPodDisruptionBudgets(
 	}
 
 	// TODO: Remove forced ownership in v1.5 (#672)
-	_, _, err = resourceapply.ApplyPodDisruptionBudget(ctx, scc.kubeClient.PolicyV1beta1(), scc.pdbLister, scc.eventRecorder, requiredPDB, true)
+	_, _, err = resourceapply.ApplyPodDisruptionBudget(ctx, scc.kubeClient.PolicyV1(), scc.pdbLister, scc.eventRecorder, requiredPDB, true)
 	if err != nil {
 		return status, fmt.Errorf("can't apply pdb: %w", err)
 	}

--- a/pkg/resourceapply/policy.go
+++ b/pkg/resourceapply/policy.go
@@ -7,11 +7,11 @@ import (
 	"fmt"
 
 	"github.com/scylladb/scylla-operator/pkg/naming"
-	policyv1beta1 "k8s.io/api/policy/v1beta1"
+	policyv1 "k8s.io/api/policy/v1"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	policyv1beta1client "k8s.io/client-go/kubernetes/typed/policy/v1beta1"
-	policyv1beta1listers "k8s.io/client-go/listers/policy/v1beta1"
+	policyv1client "k8s.io/client-go/kubernetes/typed/policy/v1"
+	policyv1listers "k8s.io/client-go/listers/policy/v1"
 	"k8s.io/client-go/tools/record"
 	"k8s.io/klog/v2"
 )
@@ -21,12 +21,12 @@ import (
 // would be adopted but the old objects may not have correct labels that we need to fix in the new version.
 func ApplyPodDisruptionBudget(
 	ctx context.Context,
-	client policyv1beta1client.PodDisruptionBudgetsGetter,
-	lister policyv1beta1listers.PodDisruptionBudgetLister,
+	client policyv1client.PodDisruptionBudgetsGetter,
+	lister policyv1listers.PodDisruptionBudgetLister,
 	recorder record.EventRecorder,
-	required *policyv1beta1.PodDisruptionBudget,
+	required *policyv1.PodDisruptionBudget,
 	forceOwnership bool,
-) (*policyv1beta1.PodDisruptionBudget, bool, error) {
+) (*policyv1.PodDisruptionBudget, bool, error) {
 	requiredControllerRef := metav1.GetControllerOfNoCopy(required)
 	if requiredControllerRef == nil {
 		return nil, false, fmt.Errorf("poddisruptionbudget %q is missing controllerRef", naming.ObjRef(required))

--- a/test/e2e/set/scyllacluster/scyllacluster_evictions.go
+++ b/test/e2e/set/scyllacluster/scyllacluster_evictions.go
@@ -10,7 +10,7 @@ import (
 	scyllafixture "github.com/scylladb/scylla-operator/test/e2e/fixture/scylla"
 	"github.com/scylladb/scylla-operator/test/e2e/framework"
 	"github.com/scylladb/scylla-operator/test/e2e/utils"
-	policyv1beta1 "k8s.io/api/policy/v1beta1"
+	policyv1 "k8s.io/api/policy/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
@@ -49,23 +49,23 @@ var _ = g.Describe("ScyllaCluster evictions", func() {
 		verifyScyllaCluster(ctx, f.KubeClient(), sc, di)
 
 		framework.By("Allowing the first pod to be evicted")
-		e := &policyv1beta1.Eviction{
+		e := &policyv1.Eviction{
 			ObjectMeta: metav1.ObjectMeta{
 				Name:      utils.GetNodeName(sc, 0),
 				Namespace: f.Namespace(),
 			},
 		}
-		err = f.KubeAdminClient().CoreV1().Pods(f.Namespace()).Evict(ctx, e)
+		err = f.KubeAdminClient().CoreV1().Pods(f.Namespace()).EvictV1(ctx, e)
 		o.Expect(err).NotTo(o.HaveOccurred())
 
 		framework.By("Forbidding to evict a second pod")
-		e = &policyv1beta1.Eviction{
+		e = &policyv1.Eviction{
 			ObjectMeta: metav1.ObjectMeta{
 				Name:      utils.GetNodeName(sc, 1),
 				Namespace: f.Namespace(),
 			},
 		}
-		err = f.KubeAdminClient().CoreV1().Pods(f.Namespace()).Evict(ctx, e)
+		err = f.KubeAdminClient().CoreV1().Pods(f.Namespace()).EvictV1(ctx, e)
 		o.Expect(err).Should(o.MatchError("Cannot evict pod as it would violate the pod's disruption budget."))
 	})
 })

--- a/test/e2e/set/scyllacluster/verify.go
+++ b/test/e2e/set/scyllacluster/verify.go
@@ -11,7 +11,7 @@ import (
 	"github.com/scylladb/scylla-operator/test/e2e/framework"
 	"github.com/scylladb/scylla-operator/test/e2e/utils"
 	appsv1 "k8s.io/api/apps/v1"
-	policyv1beta1 "k8s.io/api/policy/v1beta1"
+	policyv1 "k8s.io/api/policy/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/client-go/kubernetes"
 	corev1client "k8s.io/client-go/kubernetes/typed/core/v1"
@@ -63,7 +63,7 @@ func verifyStatefulset(sts *appsv1.StatefulSet) {
 	o.Expect(sts.Status.CurrentRevision).To(o.Equal(sts.Status.UpdateRevision))
 }
 
-func verifyPodDisruptionBudget(sc *scyllav1.ScyllaCluster, pdb *policyv1beta1.PodDisruptionBudget) {
+func verifyPodDisruptionBudget(sc *scyllav1.ScyllaCluster, pdb *policyv1.PodDisruptionBudget) {
 	o.Expect(pdb.ObjectMeta.OwnerReferences).To(o.BeEquivalentTo(
 		[]metav1.OwnerReference{
 			{
@@ -110,7 +110,7 @@ func verifyScyllaCluster(ctx context.Context, kubeClient kubernetes.Interface, s
 		o.Expect(sc.Status.Upgrade.FromVersion).To(o.Equal(sc.Status.Upgrade.ToVersion))
 	}
 
-	pdb, err := kubeClient.PolicyV1beta1().PodDisruptionBudgets(sc.Namespace).Get(ctx, naming.PodDisruptionBudgetName(sc), metav1.GetOptions{})
+	pdb, err := kubeClient.PolicyV1().PodDisruptionBudgets(sc.Namespace).Get(ctx, naming.PodDisruptionBudgetName(sc), metav1.GetOptions{})
 	o.Expect(err).NotTo(o.HaveOccurred())
 	verifyPodDisruptionBudget(sc, pdb)
 


### PR DESCRIPTION
# Description

Migrate to `policy/v1`.

# Related Docs

https://kubernetes.io/docs/reference/using-api/deprecation-guide/#poddisruptionbudget-v125
